### PR TITLE
 Added new route for visualizations 

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -15,9 +15,11 @@
 
 import { NoteRouter } from './noteRouter';
 import { ParaRouter } from './paraRouter';
+import { vizRouter } from './vizRouter';
 import { IRouter } from '../../../../src/core/server';
 
 export function serverRoute(router: IRouter) {
   ParaRouter(router);
   NoteRouter(router);
+  vizRouter(router);
 }

--- a/server/routes/noteRouter.ts
+++ b/server/routes/noteRouter.ts
@@ -23,7 +23,7 @@ export function NoteRouter(router: IRouter) {
   router.get(
     {
       path: `${API_PREFIX}/`,
-      validate: false,
+      validate: {},
     },
     async (context, request, response): Promise<IKibanaResponse<any | ResponseError>> => {
       let notebooksData = [];

--- a/server/routes/vizRouter.ts
+++ b/server/routes/vizRouter.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { IRouter, IKibanaResponse, ResponseError } from '../../../../src/core/server';
+import { API_PREFIX } from '../../common';
+import { RequestParams } from '@elastic/elasticsearch';
+
+export function vizRouter(router: IRouter) {
+  router.get(
+    {
+      path: `${API_PREFIX}/visualizations`,
+      validate: {},
+    },
+    async (context, request, response): Promise<IKibanaResponse<any | ResponseError>> => {
+      const params: RequestParams.Search = {
+        index: '.kibana',
+        q: 'type:visualization',
+      };
+      try {
+        const esClientResponse = await context.core.elasticsearch.legacy.client.callAsInternalUser(
+          'search',
+          params
+        );
+        const savedVisualizations = esClientResponse.hits.hits;
+        const vizResponse = savedVisualizations.map((vizDocument) => ({
+          label: vizDocument._source.visualization.title,
+          key: vizDocument._id.split(':').pop(),
+        }));
+        return response.ok({
+          body: { savedVisualizations: vizResponse },
+        });
+      } catch (error) {
+        return response.custom({
+          statusCode: error.statusCode || 500,
+          body: error.message,
+        });
+      }
+    }
+  );
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Added a new route for visualizations to confine embedding saved visualization to user roles
2. Minor edits to noteRouter.ts and index.ts

Notes: This is similar to [getDashboards](https://github.com/opendistro-for-elasticsearch/kibana-reports/blob/dev/server/routes/getDashboards.ts) in Kibana-Reports 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
