### PR TITLE
Enable notebooks only in global tenants

### DIFF
--- a/public/components/helpers/helper_functions.tsx
+++ b/public/components/helpers/helper_functions.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { CoreStart } from 'kibana/public';
+
+// returns true if in global tenant or security plugin doesn't exist
+export const isGlobalSecurityTenant = (http: CoreStart['http']) => {
+  return http
+    .get('/api/v1/configuration/account')
+    .then((res) => {
+      if (typeof res?.data?.user_requested_tenant === 'string')
+        return res.data.user_requested_tenant === '';
+      return true;
+    })
+    .catch((e) => true);
+};

--- a/public/components/main.tsx
+++ b/public/components/main.tsx
@@ -26,6 +26,7 @@ import { HashRouter } from 'react-router-dom';
 import { Switch, Route } from 'react-router';
 import { EuiGlobalToastList, EuiLink } from '@elastic/eui';
 import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
+import { isGlobalSecurityTenant } from './helpers/helper_functions';
 
 /*
  * "Main" component renders the whole Notebooks as a single page application
@@ -80,7 +81,11 @@ export class Main extends React.Component<MainProps, MainState> {
   }
 
   // Fetches path and id for all stored notebooks
-  fetchNotebooks = () => {
+  fetchNotebooks = async () => {
+    if (!(await isGlobalSecurityTenant(this.props.http))) {
+      this.setToast('Notebooks is only available in the global tenant.', 'danger');
+      return;
+    }
     return this.props.http
       .get(`${API_PREFIX}/`)
       .then((res) => this.setState(res))
@@ -90,7 +95,11 @@ export class Main extends React.Component<MainProps, MainState> {
   };
 
   // Creates a new notebook
-  createNotebook = (newNoteName: string) => {
+  createNotebook = async (newNoteName: string) => {
+    if (!(await isGlobalSecurityTenant(this.props.http))) {
+      this.setToast('Notebooks is only available in the global tenant.', 'danger');
+      return;
+    }
     if (newNoteName.length >= 50 || newNoteName.length === 0) {
       this.setToast('Invalid notebook name', 'danger');
       return;


### PR DESCRIPTION
*Issue #, if available:*
- related to #59 

*Description of changes:*
- If security plugin is present, enable notebooks only in global tenant so that permission of visualizations in notebooks is consistent for all users.

If user is in private or custom tenant, notebooks shows an error to indicate its only available in global tenant.
![image](https://user-images.githubusercontent.com/28062824/100646473-ea575b00-32f2-11eb-826f-f5d7bb0f1c3c.png)

If user has access to `.kibana*` (saved objects) but not the data index, the user will see the visualization title but content will be empty with an error `[esaggs] > Forbidden`.
![image](https://user-images.githubusercontent.com/28062824/100646631-1e328080-32f3-11eb-921e-8a25aec59b92.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
