### PR TITLE
Use separate Notebooks ES plugin for all requests to support user/tenants

### DIFF
--- a/.cypress/integration/ui.spec.js
+++ b/.cypress/integration/ui.spec.js
@@ -82,8 +82,9 @@ describe('Testing notebooks table', () => {
     cy.get('.euiFormControlLayoutClearButton').click();
     cy.wait(delay);
     cy.get('input.euiFieldSearch').type(TEST_NOTEBOOK + ' (copy) (rename)');
+    cy.wait(delay);
 
-    cy.get('.euiLink[href*="#note_"').should('exist');
+    cy.get('a.euiLink').contains(TEST_NOTEBOOK + ' (copy) (rename)').should('exist');
   });
 
   it('Deletes notebooks', () => {

--- a/common/index.ts
+++ b/common/index.ts
@@ -31,6 +31,12 @@ export const wreckOptions = {
   headers: { 'Content-Type': 'application/json' },
 };
 
+const BASE_NOTEBOOKS_URI = '/_opendistro/_notebooks';
+export const ES_NOTEBOOKS_API = {
+  GET_NOTEBOOKS: `${BASE_NOTEBOOKS_URI}/notebooks`,
+  NOTEBOOK: `${BASE_NOTEBOOKS_URI}/notebook`,
+};
+
 export interface optionsType {
   baseUrl: string;
   payload?: any;

--- a/public/components/main.tsx
+++ b/public/components/main.tsx
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import React from 'react';
+import React, { ReactChild } from 'react';
 
 import { CoreStart, ChromeBreadcrumb } from '../../../../src/core/public';
 import { DashboardStart } from '../../../../src/plugins/dashboard/public';
@@ -68,15 +68,16 @@ export class Main extends React.Component<MainProps, MainState> {
     };
   }
 
-  setToast = (title: string, color = 'success', text = '') => {
-    this.setState({
-      toasts: [{
+  setToast = (title: string, color = 'success', text?: ReactChild) => {
+    if (!text) text = '';
+    this.setState((prevState) => ({
+      toasts: [...prevState.toasts, {
         id: new Date().toISOString(),
         title,
         text,
         color,
-      }]
-    })
+      } as Toast]
+    }));
   }
 
   // Fetches path and id for all stored notebooks
@@ -130,14 +131,20 @@ export class Main extends React.Component<MainProps, MainState> {
         body: JSON.stringify(renameNoteObject),
       })
       .then((res) => {
-        this.fetchNotebooks();
+        this.setState((prevState) => {
+          const newData = [...prevState.data];
+          const renamedNotebook = newData.find((notebook) => notebook.id === editedNoteID);
+          if (renamedNotebook)
+            renamedNotebook.path = editedNoteName;
+          return { data: newData };
+        });
         this.setToast(`Notebook successfully renamed into "${editedNoteName}"`);
       })
       .catch((err) => this.setToast('Issue in renaming the notebook ' + err.body.message, 'danger'));
   };
 
-  // Clones an existing notebook
-  cloneNotebook = (clonedNoteName: string, clonedNoteID: string) => {
+  // Clones an existing notebook, return new notebook's id
+  cloneNotebook = (clonedNoteName: string, clonedNoteID: string): Promise<string> => {
     const cloneNoteObject = {
       name: clonedNoteName,
       noteId: clonedNoteID,
@@ -148,9 +155,16 @@ export class Main extends React.Component<MainProps, MainState> {
         body: JSON.stringify(cloneNoteObject),
       })
       .then((res) => {
-        this.fetchNotebooks();
+        this.setState((prevState) => ({
+          data: [...prevState.data, {
+            path: clonedNoteName,
+            id: res.body.id,
+            dateCreated: res.body.dateCreated,
+            dateModified: res.body.dateModified,
+          }],
+        }));
         this.setToast(`Notebook "${clonedNoteName}" successfully created!`);
-        return res;
+        return res.body.id;
       })
       .catch((err) => this.setToast('Issue in cloning the notebook ' + err.body.message, 'danger'));
   };
@@ -160,7 +174,9 @@ export class Main extends React.Component<MainProps, MainState> {
     return this.props.http
       .delete(`${API_PREFIX}/note/` + notebookId)
       .then((res) => {
-        this.fetchNotebooks();
+        this.setState((prevState) => ({
+          data: prevState.data.filter((notebook) => notebook.id !== notebookId)
+        }));
         if (showToast)
           this.setToast(`Notebook "${notebookName}" successfully deleted!`);
       })

--- a/public/components/main.tsx
+++ b/public/components/main.tsx
@@ -179,13 +179,14 @@ export class Main extends React.Component<MainProps, MainState> {
         }));
         if (showToast)
           this.setToast(`Notebook "${notebookName}" successfully deleted!`);
+        return res;
       })
       .catch((err) => this.setToast('Issue in deleting the notebook ' + err.body.message, 'danger'));
   };
 
   render() {
     return (
-      <HashRouter basename={this.props.basename}>
+      <HashRouter>
         <>
           <EuiGlobalToastList
             toasts={this.state.toasts}

--- a/public/components/main.tsx
+++ b/public/components/main.tsx
@@ -47,7 +47,7 @@ type MainProps = {
 
 type MainState = {
   data: Array<NotebookType>;
-  openedNotebook: NotebookType;
+  openedNotebook: NotebookType | undefined;
   toasts: Toast[];
 };
 
@@ -140,11 +140,18 @@ export class Main extends React.Component<MainProps, MainState> {
         });
         this.setToast(`Notebook successfully renamed into "${editedNoteName}"`);
       })
-      .catch((err) => this.setToast('Issue in renaming the notebook ' + err.body.message, 'danger'));
+      .catch((err) => {
+        this.setToast('Error renaming notebook, please make sure you have the correct permission.', 'danger');
+        console.error(err.body.message);
+      });
   };
 
   // Clones an existing notebook, return new notebook's id
   cloneNotebook = (clonedNoteName: string, clonedNoteID: string): Promise<string> => {
+    if (clonedNoteName.length >= 50 || clonedNoteName.length === 0) {
+      this.setToast('Invalid notebook name', 'danger');
+      return Promise.reject();
+    }
     const cloneNoteObject = {
       name: clonedNoteName,
       noteId: clonedNoteID,
@@ -166,7 +173,10 @@ export class Main extends React.Component<MainProps, MainState> {
         this.setToast(`Notebook "${clonedNoteName}" successfully created!`);
         return res.body.id;
       })
-      .catch((err) => this.setToast('Issue in cloning the notebook ' + err.body.message, 'danger'));
+      .catch((err) => {
+        this.setToast('Error cloning notebook, please make sure you have the correct permission.', 'danger');
+        console.error(err.body.message);
+      });
   };
 
   // Deletes an existing notebook
@@ -181,7 +191,10 @@ export class Main extends React.Component<MainProps, MainState> {
           this.setToast(`Notebook "${notebookName}" successfully deleted!`);
         return res;
       })
-      .catch((err) => this.setToast('Issue in deleting the notebook ' + err.body.message, 'danger'));
+      .catch((err) => {
+        this.setToast('Error deleting notebook, please make sure you have the correct permission.', 'danger');
+        console.error(err.body.message);
+      });
   };
 
   render() {

--- a/public/components/main.tsx
+++ b/public/components/main.tsx
@@ -105,7 +105,7 @@ export class Main extends React.Component<MainProps, MainState> {
       })
       .then(async (res) => {
         this.setToast(`Notebook "${newNoteName}" successfully created!`);
-        window.location.assign(`${this.props.basename}#${res.body}`);
+        window.location.assign(`${this.props.basename}#${res}`);
       })
       .catch((err) => {
         this.setToast('Please ask your administrator to enable Notebooks for you.', 'danger',
@@ -150,7 +150,7 @@ export class Main extends React.Component<MainProps, MainState> {
       .then((res) => {
         this.fetchNotebooks();
         this.setToast(`Notebook "${clonedNoteName}" successfully created!`);
-        return res.body;
+        return res;
       })
       .catch((err) => this.setToast('Issue in cloning the notebook ' + err.body.message, 'danger'));
   };

--- a/public/components/note_table.tsx
+++ b/public/components/note_table.tsx
@@ -107,7 +107,10 @@ export function NoteTable(props: NoteTableProps) {
       's' : ' ' + selectedNotebooks[0].path} successfully deleted!`;
     Promise.all(selectedNotebooks.map((notebook) => deleteNotebook(notebook.id, undefined, false)))
       .then(() => props.setToast(toastMessage))
-      .catch((error) => props.setToast('Issue in deleting notebooks' + error.body.message, 'danger'));
+      .catch((err) => {
+        props.setToast('Error deleting notebooks, please make sure you have the correct permission.', 'danger');
+        console.error(err.body.message);
+      });
     closeModal();
   };
 

--- a/public/components/notebook.tsx
+++ b/public/components/notebook.tsx
@@ -273,10 +273,13 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
     this.setState({
       modalLayout: (
         <DeleteNotebookModal
-          onConfirm={() => {
-            this.props.deleteNotebook(this.props.openedNoteId, this.state.path);
-            this.setState({ isModalVisible: false });
-            window.location.replace(`${this.props.basename}#`);
+          onConfirm={async () => {
+            await this.props.deleteNotebook(this.props.openedNoteId, this.state.path);
+            this.setState({ isModalVisible: false }, () =>
+              setTimeout(() => {
+                window.location.replace(`${this.props.basename}#`);
+              }, 300)
+            );
           }}
           onCancel={() => this.setState({ isModalVisible: false })}
           title={`Delete notebook "${this.state.path}"`}

--- a/public/components/notebook.tsx
+++ b/public/components/notebook.tsx
@@ -124,8 +124,9 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
         para.paraDivRef = React.createRef<HTMLDivElement>();
       });
       return parsedPara;
-    } catch (error) {
-      console.error('Parsing paragraph has some issue', error);
+    } catch (err) {
+      this.props.setToast('Error parsing paragraphs, please make sure you have the correct permission.', 'danger');
+      console.error(err);
       this.setState({ parsedPara: [] });
     }
   };
@@ -170,7 +171,10 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
           parsedPara.splice(index, 1);
           this.setState({ paragraphs, parsedPara });
         })
-        .catch((err) => console.error('Delete paragraph issue: ', err.body.message));
+      .catch((err) => {
+        this.props.setToast('Error deleting paragraph, please make sure you have the correct permission.', 'danger');
+        console.error(err.body.message);
+      });
     }
   };
 
@@ -201,7 +205,10 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                 this.setState({ paragraphs: res.paragraphs });
                 this.parseAllParagraphs();
               })
-              .catch((err) => console.error('Delete paragraph issue: ', err.body.message));
+              .catch((err) => {
+                this.props.setToast('Error deleting paragraph, please make sure you have the correct permission.', 'danger');
+                console.error(err.body.message);
+              });
           });
           this.props.setToast('Paragraphs successfully deleted!');
         },
@@ -298,7 +305,10 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
         this.setState({ paragraphs: res.paragraphs });
         this.parseAllParagraphs();
       })
-      .catch((err) => console.error('Delete vizualization issue: ', err.body.message));
+      .catch((err) => {
+        this.props.setToast('Error deleting visualization, please make sure you have the correct permission.', 'danger');
+        console.error(err.body.message);
+      });
   };
 
   // Backend call to add a paragraph
@@ -325,7 +335,10 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
         this.setState({ paragraphs, parsedPara });
         this.paragraphSelector(index);
       })
-      .catch((err) => console.error('Add paragraph issue: ', err.body.message));
+      .catch((err) => {
+        this.props.setToast('Error adding paragraph, please make sure you have the correct permission.', 'danger');
+        console.error(err.body.message);
+      });
   };
 
   // Function to clone a paragraph
@@ -357,7 +370,10 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
       })
       .then((res) => this.setState({ paragraphs, parsedPara }))
       .then((res) => this.scrollToPara(targetIndex))
-      .catch((err) => console.error('Move paragraph issue: ', err.body.message));
+      .catch((err) => {
+        this.props.setToast('Error moving paragraphs, please make sure you have the correct permission.', 'danger');
+        console.error(err.body.message);
+      });
   };
 
   scrollToPara(index: number) {
@@ -384,7 +400,10 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
         this.setState({ paragraphs: res.paragraphs });
         this.parseAllParagraphs();
       })
-      .catch((err) => console.error('clear paragraph issue: ', err.body.message));
+      .catch((err) => {
+        this.props.setToast('Error clearing paragraphs, please make sure you have the correct permission.', 'danger');
+        console.error(err.body.message);
+      });
   };
 
   // Backend call to update and run contents of paragraph
@@ -411,7 +430,10 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
         parsedPara[index] = this.parseParagraphs([res])[0];
         this.setState({ paragraphs, parsedPara });
       })
-      .catch((err) => console.error('run paragraph issue: ', err.body.message));
+      .catch((err) => {
+        this.props.setToast('Error running paragraph, please make sure you have the correct permission.', 'danger');
+        console.error(err.body.message);
+      });
   };
 
   runForAllParagraphs = (reducer: (para: ParaType, index: number) => Promise<any>) => {
@@ -458,7 +480,10 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
         this.setBreadcrumbs(res.path);
         this.setState(res, this.parseAllParagraphs);
       })
-      .catch((err) => console.error('Fetching notebook issue: ', err.body.message));
+    .catch((err) => {
+      this.props.setToast('Error fetching notebooks, please make sure you have the correct permission.', 'danger');
+      console.error(err.body.message);
+    });
   };
 
   setPara = (para: ParaType, index: number) => {
@@ -481,6 +506,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
   }
 
   componentDidMount() {
+    this.setBreadcrumbs('');
     this.loadNotebook();
   }
 

--- a/public/components/notebook.tsx
+++ b/public/components/notebook.tsx
@@ -254,7 +254,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
               window.location.assign(`${this.props.basename}#${id}`);
               setTimeout(() => {
                 this.loadNotebook()
-              }, 100);
+              }, 300);
             });
           this.setState({ isModalVisible: false });
         },

--- a/server/adaptors/default_backend.ts
+++ b/server/adaptors/default_backend.ts
@@ -140,7 +140,7 @@ export class DefaultBackend implements NotebookAdaptor {
     try {
       const newNotebook = this.createNewNotebook(params.name);
       const esClientResponse = await this.indexNote(client, newNotebook.object);
-      return { status: 'OK', message: esClientResponse, body: esClientResponse._id };
+      return { status: 'OK', message: esClientResponse, body: esClientResponse.notebookId };
     } catch (error) {
       throw new Error('Creating New Notebook Error:' + error);
     }
@@ -182,7 +182,7 @@ export class DefaultBackend implements NotebookAdaptor {
       const cloneNotebook = { ...newNotebook.object };
       cloneNotebook.paragraphs = noteObject.notebook.paragraphs;
       const esClientIndexResponse = await this.indexNote(client, cloneNotebook);
-      return { status: 'OK', message: esClientIndexResponse, body: esClientIndexResponse._id };
+      return { status: 'OK', body: { ...cloneNotebook, id: esClientIndexResponse.notebookId } };
     } catch (error) {
       throw new Error('Cloning Notebook Error:' + error);
     }
@@ -236,7 +236,7 @@ export class DefaultBackend implements NotebookAdaptor {
       newNoteObject.dateCreated = new Date().toISOString();
       newNoteObject.dateModified = new Date().toISOString();
       const esClientIndexResponse = await this.indexNote(client, newNoteObject);
-      return { status: 'OK', message: esClientIndexResponse, body: esClientIndexResponse._id };
+      return { status: 'OK', message: esClientIndexResponse, body: esClientIndexResponse.notebookId };
     } catch (error) {
       throw new Error('Import Notebook Error:' + error);
     }

--- a/server/adaptors/default_backend.ts
+++ b/server/adaptors/default_backend.ts
@@ -64,7 +64,7 @@ export class DefaultBackend implements NotebookAdaptor {
   updateNote = async function (
     client: ILegacyScopedClusterClient,
     noteId: string,
-    updateBody: string
+    updateBody: Partial<DefaultNotebooks>
   ) {
     try {
       const response = await client.callAsCurrentUser('notebooks.updateNotebookById', {
@@ -180,7 +180,7 @@ export class DefaultBackend implements NotebookAdaptor {
       const noteObject = await this.getNote(client, params.noteId);
       const newNotebook = this.createNewNotebook(params.name);
       const cloneNotebook = { ...newNotebook.object };
-      cloneNotebook.paragraphs = noteObject.paragraphs;
+      cloneNotebook.paragraphs = noteObject.notebook.paragraphs;
       const esClientIndexResponse = await this.indexNote(client, cloneNotebook);
       return { status: 'OK', message: esClientIndexResponse, body: esClientIndexResponse._id };
     } catch (error) {
@@ -253,7 +253,7 @@ export class DefaultBackend implements NotebookAdaptor {
     paragraphInput: string
   ) {
     try {
-      const updatedParagraphs = [];
+      const updatedParagraphs: DefaultParagraph[] = [];
       paragraphs.map((paragraph: DefaultParagraph) => {
         const updatedParagraph = { ...paragraph };
         if (paragraph.id === paragraphId) {
@@ -352,7 +352,7 @@ export class DefaultBackend implements NotebookAdaptor {
     try {
       const esClientGetResponse = await this.getNote(client, params.noteId);
       const updatedInputParagraphs = this.updateParagraphInput(
-        esClientGetResponse.paragraphs,
+        esClientGetResponse.notebook.paragraphs,
         params.paragraphId,
         params.paragraphInput
       );
@@ -394,7 +394,7 @@ export class DefaultBackend implements NotebookAdaptor {
     try {
       const esClientGetResponse = await this.getNote(client, params.noteId);
       const updatedInputParagraphs = this.updateParagraphInput(
-        esClientGetResponse.paragraphs,
+        esClientGetResponse.notebook.paragraphs,
         params.paragraphId,
         params.paragraphInput
       );
@@ -430,7 +430,7 @@ export class DefaultBackend implements NotebookAdaptor {
   ) {
     try {
       const esClientGetResponse = await this.getNote(client, params.noteId);
-      const paragraphs = esClientGetResponse.paragraphs;
+      const paragraphs = esClientGetResponse.notebook.paragraphs;
       const newParagraph = this.createParagraph(params.paragraphInput, params.inputType);
       paragraphs.splice(params.paragraphIndex, 0, newParagraph);
       const updateNotebook = {
@@ -458,8 +458,8 @@ export class DefaultBackend implements NotebookAdaptor {
   ) {
     try {
       const esClientGetResponse = await this.getNote(client, params.noteId);
-      let updatedparagraphs = [];
-      esClientGetResponse.paragraphs.map((paragraph: DefaultParagraph, index: number) => {
+      const updatedparagraphs: DefaultParagraph[] = [];
+      esClientGetResponse.notebook.paragraphs.map((paragraph: DefaultParagraph, index: number) => {
         if (paragraph.id !== params.paragraphId) {
           updatedparagraphs.push(paragraph);
         }
@@ -473,6 +473,7 @@ export class DefaultBackend implements NotebookAdaptor {
 
       return { paragraphs: updatedparagraphs };
     } catch (error) {
+      console.log('error', error);
       throw new Error('Delete Paragraph Error:' + error);
     }
   };
@@ -489,8 +490,8 @@ export class DefaultBackend implements NotebookAdaptor {
   ) {
     try {
       const esClientGetResponse = await this.getNote(client, params.noteId);
-      let updatedparagraphs = [];
-      esClientGetResponse.paragraphs.map((paragraph: DefaultParagraph, index: number) => {
+      let updatedparagraphs: DefaultParagraph[] = [];
+      esClientGetResponse.notebook.paragraphs.map((paragraph: DefaultParagraph, index: number) => {
         let updatedParagraph = { ...paragraph };
         updatedParagraph.output = [];
         updatedparagraphs.push(updatedParagraph);

--- a/server/adaptors/es_notebooks_plugin.ts
+++ b/server/adaptors/es_notebooks_plugin.ts
@@ -41,6 +41,7 @@ export function NotebooksPlugin(Client: any, config: any, components: any) {
       fmt: ES_NOTEBOOKS_API.NOTEBOOK,
     },
     method: 'POST',
+    needBody: true,
   });
 
   notebooks.getNotebookById = clientAction({
@@ -67,6 +68,7 @@ export function NotebooksPlugin(Client: any, config: any, components: any) {
       },
     },
     method: 'PUT',
+    needBody: true,
   });
 
   notebooks.deleteNotebookById = clientAction({

--- a/server/adaptors/es_notebooks_plugin.ts
+++ b/server/adaptors/es_notebooks_plugin.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { ES_NOTEBOOKS_API } from "../../common";
+
+export function NotebooksPlugin(Client: any, config: any, components: any) {
+  const clientAction = components.clientAction.factory;
+
+  Client.prototype.notebooks = components.clientAction.namespaceFactory();
+  const notebooks = Client.prototype.notebooks.prototype;
+
+  notebooks.getNotebooks = clientAction({
+    url: {
+      fmt: ES_NOTEBOOKS_API.GET_NOTEBOOKS,
+      params: {
+        fromIndex: {
+          type: 'number',
+        },
+        maxItems: {
+          type: 'number',
+        },
+      },
+    },
+    method: 'GET',
+  });
+
+  notebooks.createNotebook = clientAction({
+    url: {
+      fmt: ES_NOTEBOOKS_API.NOTEBOOK,
+    },
+    method: 'POST',
+  });
+
+  notebooks.getNotebookById = clientAction({
+    url: {
+      fmt: `${ES_NOTEBOOKS_API.NOTEBOOK}/<%=notebookId%>`,
+      req: {
+        notebookId: {
+          type: 'string',
+          required: true,
+        },
+      },
+    },
+    method: 'GET',
+  });
+
+  notebooks.updateNotebookById = clientAction({
+    url: {
+      fmt: `${ES_NOTEBOOKS_API.NOTEBOOK}/<%=notebookId%>`,
+      req: {
+        notebookId: {
+          type: 'string',
+          required: true,
+        },
+      },
+    },
+    method: 'PUT',
+  });
+
+  notebooks.deleteNotebookById = clientAction({
+    url: {
+      fmt: `${ES_NOTEBOOKS_API.NOTEBOOK}/<%=notebookId%>`,
+      req: {
+        notebookId: {
+          type: 'string',
+          required: true,
+        },
+      },
+    },
+    method: 'DELETE',
+  });
+
+}

--- a/server/adaptors/notebook_adaptor.ts
+++ b/server/adaptors/notebook_adaptor.ts
@@ -13,20 +13,20 @@
  * permissions and limitations under the License.
  */
 
-import { RequestHandlerContext } from '../../../../src/core/server';
+import { ILegacyScopedClusterClient, RequestHandlerContext } from '../../../../src/core/server';
 import { optionsType } from '../../common';
 
 export interface NotebookAdaptor {
   backend: string;
 
   // Gets all the notebooks available
-  viewNotes: (context: RequestHandlerContext, wreckOptions: optionsType) => Promise<any[]>;
+  viewNotes: (client: ILegacyScopedClusterClient, wreckOptions: optionsType) => Promise<any[]>;
 
   /* Fetches a notebook by id
    * Param: noteId -> Id of notebook to be fetched
    */
   fetchNote: (
-    context: RequestHandlerContext,
+    client: ILegacyScopedClusterClient,
     noteId: string,
     wreckOptions: optionsType
   ) => Promise<any>;
@@ -35,7 +35,7 @@ export interface NotebookAdaptor {
    * Param: name -> name of new notebook
    */
   addNote: (
-    context: RequestHandlerContext,
+    client: ILegacyScopedClusterClient,
     params: { name: string },
     wreckOptions: optionsType
   ) => Promise<any>;
@@ -45,7 +45,7 @@ export interface NotebookAdaptor {
    *         noteId -> Id of notebook to be fetched
    */
   renameNote: (
-    context: RequestHandlerContext,
+    client: ILegacyScopedClusterClient,
     params: { name: string; noteId: string },
     wreckOptions: optionsType
   ) => Promise<any>;
@@ -55,7 +55,7 @@ export interface NotebookAdaptor {
    *         noteId -> Id for the notebook to be cloned
    */
   cloneNote: (
-    context: RequestHandlerContext,
+    client: ILegacyScopedClusterClient,
     params: { name: string; noteId: string },
     wreckOptions: optionsType
   ) => Promise<any>;
@@ -64,7 +64,7 @@ export interface NotebookAdaptor {
    * Param: noteId -> Id for the notebook to be deleted
    */
   deleteNote: (
-    context: RequestHandlerContext,
+    client: ILegacyScopedClusterClient,
     noteId: string,
     wreckOptions: optionsType
   ) => Promise<any>;
@@ -73,7 +73,7 @@ export interface NotebookAdaptor {
    * Param: noteId -> Id for the notebook to be exported
    */
   exportNote: (
-    context: RequestHandlerContext,
+    client: ILegacyScopedClusterClient,
     noteId: string,
     wreckOptions: optionsType
   ) => Promise<any>;
@@ -82,7 +82,7 @@ export interface NotebookAdaptor {
    * Params: noteObj -> note Object to be imported
    */
   importNote: (
-    context: RequestHandlerContext,
+    client: ILegacyScopedClusterClient,
     noteObj: any,
     wreckOptions: optionsType
   ) => Promise<any>;
@@ -95,7 +95,7 @@ export interface NotebookAdaptor {
    *         paragraphInput -> paragraph input code
    */
   updateRunFetchParagraph: (
-    context: RequestHandlerContext,
+    client: ILegacyScopedClusterClient,
     params: { noteId: string; paragraphId: string; paragraphInput: string },
     wreckOptions: optionsType
   ) => Promise<any>;
@@ -107,7 +107,7 @@ export interface NotebookAdaptor {
    *         paragraphInput -> paragraph input code
    */
   updateFetchParagraph: (
-    context: RequestHandlerContext,
+    client: ILegacyScopedClusterClient,
     params: { noteId: string; paragraphId: string; paragraphInput: string },
     wreckOptions: optionsType
   ) => Promise<any>;
@@ -118,7 +118,7 @@ export interface NotebookAdaptor {
    *         paragraphId -> Id of the paragraph to be fetched
    */
   addFetchNewParagraph: (
-    context: RequestHandlerContext,
+    client: ILegacyScopedClusterClient,
     params: { noteId: string; paragraphIndex: number; paragraphInput: string; inputType: string },
     wreckOptions: optionsType
   ) => Promise<any>;
@@ -129,7 +129,7 @@ export interface NotebookAdaptor {
    *         paragraphId -> Id of the paragraph to be deleted
    */
   deleteFetchParagraphs: (
-    context: RequestHandlerContext,
+    client: ILegacyScopedClusterClient,
     params: { noteId: string; paragraphId: string },
     wreckOptions: optionsType
   ) => Promise<{ paragraphs: any }>;
@@ -139,7 +139,7 @@ export interface NotebookAdaptor {
    * Param: noteId -> Id of notebook to be cleared
    */
   clearAllFetchParagraphs: (
-    context: RequestHandlerContext,
+    client: ILegacyScopedClusterClient,
     params: { noteId: string },
     wreckOptions: optionsType
   ) => Promise<{ paragraphs: any }>;

--- a/server/helpers/default_notebook_schema.ts
+++ b/server/helpers/default_notebook_schema.ts
@@ -34,10 +34,8 @@ export type DefaultParagraph = {
 };
 export type DefaultNotebooks = {
   name: string;
-  id: string;
   dateCreated: string;
   dateModified: string;
-  pluginVersion: string;
   backend: string;
   paragraphs: Array<DefaultParagraph>;
 };

--- a/server/routes/noteRouter.ts
+++ b/server/routes/noteRouter.ts
@@ -63,8 +63,11 @@ export function NoteRouter(router: IRouter) {
       },
     },
     async (context, request, response): Promise<IKibanaResponse<any | ResponseError>> => {
+      const esNotebooksClient: ILegacyScopedClusterClient = context.notebooks_plugin.esNotebooksClient.asScoped(
+        request
+      );
       try {
-        const notebookinfo = await BACKEND.fetchNote(context, request.params.noteId, wreckOptions);
+        const notebookinfo = await BACKEND.fetchNote(esNotebooksClient, request.params.noteId, wreckOptions);
         return response.ok({
           body: notebookinfo,
         });
@@ -118,9 +121,11 @@ export function NoteRouter(router: IRouter) {
       },
     },
     async (context, request, response): Promise<IKibanaResponse<any | ResponseError>> => {
-      let renameResponse = {};
+      const esNotebooksClient: ILegacyScopedClusterClient = context.notebooks_plugin.esNotebooksClient.asScoped(
+        request
+      );
       try {
-        renameResponse = await BACKEND.renameNote(context, request.body, wreckOptions);
+        const renameResponse = await BACKEND.renameNote(esNotebooksClient, request.body, wreckOptions);
         return response.ok({
           body: renameResponse,
         });
@@ -145,9 +150,11 @@ export function NoteRouter(router: IRouter) {
       },
     },
     async (context, request, response): Promise<IKibanaResponse<any | ResponseError>> => {
-      let cloneResponse = {};
+      const esNotebooksClient: ILegacyScopedClusterClient = context.notebooks_plugin.esNotebooksClient.asScoped(
+        request
+      );
       try {
-        const cloneResponse = await BACKEND.cloneNote(context, request.body, wreckOptions);
+        const cloneResponse = await BACKEND.cloneNote(esNotebooksClient, request.body, wreckOptions);
         return response.ok({
           body: cloneResponse,
         });
@@ -171,8 +178,11 @@ export function NoteRouter(router: IRouter) {
       },
     },
     async (context, request, response): Promise<IKibanaResponse<any | ResponseError>> => {
+      const esNotebooksClient: ILegacyScopedClusterClient = context.notebooks_plugin.esNotebooksClient.asScoped(
+        request
+      );
       try {
-        const delResponse = await BACKEND.deleteNote(context, request.params.noteid, wreckOptions);
+        const delResponse = await BACKEND.deleteNote(esNotebooksClient, request.params.noteid, wreckOptions);
         return response.ok({
           body: delResponse,
         });

--- a/server/routes/noteRouter.ts
+++ b/server/routes/noteRouter.ts
@@ -100,7 +100,6 @@ export function NoteRouter(router: IRouter) {
           body: addResponse.message.notebookId,
         });
       } catch (error) {
-        console.log('error', error);
         return response.custom({
           statusCode: error.statusCode || 500,
           body: error.message,

--- a/server/routes/paraRouter.ts
+++ b/server/routes/paraRouter.ts
@@ -14,9 +14,10 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { IRouter, IKibanaResponse, ResponseError } from '../../../../src/core/server';
+import { IRouter, IKibanaResponse, ResponseError, ILegacyScopedClusterClient } from '../../../../src/core/server';
 import { API_PREFIX, wreckOptions } from '../../common';
 import BACKEND from '../adaptors';
+import { DefaultNotebooks, DefaultParagraph } from '../helpers/default_notebook_schema';
 
 export function ParaRouter(router: IRouter) {
   /* --> Updates the input content in a paragraph
@@ -35,9 +36,12 @@ export function ParaRouter(router: IRouter) {
       },
     },
     async (context, request, response): Promise<IKibanaResponse<any | ResponseError>> => {
+      const esNotebooksClient: ILegacyScopedClusterClient = context.notebooks_plugin.esNotebooksClient.asScoped(
+        request
+      );
       try {
         const runResponse = await BACKEND.updateRunFetchParagraph(
-          context,
+          esNotebooksClient,
           request.body,
           wreckOptions
         );
@@ -68,9 +72,12 @@ export function ParaRouter(router: IRouter) {
       },
     },
     async (context, request, response): Promise<IKibanaResponse<any | ResponseError>> => {
+      const esNotebooksClient: ILegacyScopedClusterClient = context.notebooks_plugin.esNotebooksClient.asScoped(
+        request
+      );
       try {
         const saveResponse = await BACKEND.updateFetchParagraph(
-          context,
+          esNotebooksClient,
           request.body,
           wreckOptions
         );
@@ -102,8 +109,11 @@ export function ParaRouter(router: IRouter) {
       },
     },
     async (context, request, response): Promise<IKibanaResponse<any | ResponseError>> => {
+      const esNotebooksClient: ILegacyScopedClusterClient = context.notebooks_plugin.esNotebooksClient.asScoped(
+        request
+      );
       try {
-        const addResponse = await BACKEND.addFetchNewParagraph(context, request.body, wreckOptions);
+        const addResponse = await BACKEND.addFetchNewParagraph(esNotebooksClient, request.body, wreckOptions);
         return response.ok({
           body: addResponse,
         });
@@ -139,12 +149,15 @@ export function ParaRouter(router: IRouter) {
       },
     },
     async (context, request, response): Promise<IKibanaResponse<any | ResponseError>> => {
+      const esNotebooksClient: ILegacyScopedClusterClient = context.notebooks_plugin.esNotebooksClient.asScoped(
+        request
+      );
       try {
-        const updateNotebook = {
-          paragraphs: request.body.paragraphs,
+        const updateNotebook: Partial<DefaultNotebooks> = {
+          paragraphs: request.body.paragraphs as Array<DefaultParagraph>,
           dateModified: new Date().toISOString(),
         };
-        const updateResponse = await BACKEND.updateNote(context, request.body.noteId, updateNotebook);
+        const updateResponse = await BACKEND.updateNote(esNotebooksClient, request.body.noteId, updateNotebook);
         return response.ok({
           body: updateResponse,
         });
@@ -170,12 +183,15 @@ export function ParaRouter(router: IRouter) {
       },
     },
     async (context, request, response): Promise<IKibanaResponse<any | ResponseError>> => {
+      const esNotebooksClient: ILegacyScopedClusterClient = context.notebooks_plugin.esNotebooksClient.asScoped(
+        request
+      );
       const params = {
         noteId: request.params.ids.split('/')[0],
         paragraphId: request.params.ids.split('/')[1],
       };
       try {
-        const deleteResponse = await BACKEND.deleteFetchParagraphs(context, params, wreckOptions);
+        const deleteResponse = await BACKEND.deleteFetchParagraphs(esNotebooksClient, params, wreckOptions);
         return response.ok({
           body: deleteResponse,
         });
@@ -201,9 +217,12 @@ export function ParaRouter(router: IRouter) {
       },
     },
     async (context, request, response): Promise<IKibanaResponse<any | ResponseError>> => {
+      const esNotebooksClient: ILegacyScopedClusterClient = context.notebooks_plugin.esNotebooksClient.asScoped(
+        request
+      );
       try {
         const clearParaResponse = await BACKEND.clearAllFetchParagraphs(
-          context,
+          esNotebooksClient,
           request.body,
           wreckOptions
         );


### PR DESCRIPTION
*Issue #, if available:*
- #59 

*Description of changes:*
- Call notebooks es plugin from kibana server instead of calling ES directly, this way we can use ES plugin to manage user/tenant permissions in notebooks index
- Adjust frontend functions as some api response schema changed
- Minor bug fixes: 
    - allow multiple toasts
    - fix react router basename warning

Note: will send another PR to reorganize directory structure and add Notebooks ES plugin in this repo, currently the ES plugin is [here](https://github.com/joshuali925/notebooks)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
