### PR TITLE
Fix babel command on windows

### DIFF
--- a/kibana-notebooks/package.json
+++ b/kibana-notebooks/package.json
@@ -19,15 +19,15 @@
     "test:server": "yarn plugin-helpers test:server",
     "test:browser": "yarn plugin-helpers test:browser",
     "test:cypress": "cypress run",
-    "postinstall": "yarn run babel node_modules/@nteract/markdown/lib -d node_modules/@nteract/markdown/lib; yarn run babel node_modules/@nteract/mathjax/lib -d node_modules/@nteract/mathjax/lib; yarn run babel node_modules/@nteract/outputs/lib -d node_modules/@nteract/outputs/lib; yarn run babel node_modules/@nteract/presentational-components/lib -d node_modules/@nteract/presentational-components/lib; yarn run babel node_modules/ansi-to-react/lib -d node_modules/ansi-to-react/lib;"
+    "postinstall": "yarn run babel node_modules/@nteract/markdown/lib -d node_modules/@nteract/markdown/lib && yarn run babel node_modules/@nteract/mathjax/lib -d node_modules/@nteract/mathjax/lib && yarn run babel node_modules/@nteract/outputs/lib -d node_modules/@nteract/outputs/lib && yarn run babel node_modules/@nteract/presentational-components/lib -d node_modules/@nteract/presentational-components/lib && yarn run babel node_modules/ansi-to-react/lib -d node_modules/ansi-to-react/lib"
   },
   "devDependencies": {
     "cypress": "^5.0.0",
-    "eslint": "^6.8.0"
+    "eslint": "^6.8.0",
+    "@babel/cli": "^7.10.5"
   },
   "dependencies": {
     "lodash": "^4.17.20",
-    "@babel/cli": "^7.10.5",
     "@nteract/outputs": "^3.0.11",
     "@nteract/presentational-components": "^3.4.3"
   },

--- a/kibana-notebooks/package.json
+++ b/kibana-notebooks/package.json
@@ -23,11 +23,11 @@
   },
   "devDependencies": {
     "cypress": "^5.0.0",
-    "eslint": "^6.8.0",
-    "@babel/cli": "^7.10.5"
+    "eslint": "^6.8.0"
   },
   "dependencies": {
     "lodash": "^4.17.20",
+    "@babel/cli": "^7.10.5",
     "@nteract/outputs": "^3.0.11",
     "@nteract/presentational-components": "^3.4.3"
   },


### PR DESCRIPTION
*Issue #, if available:*
- windows powershell doesn't support `command_1; command_2"

*Description of changes:*
- use `command_1 && command_2` instead
- ~~move babel to dev dependencies~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
