### PR TITLE
Use forked trim library to avoid regex DOS

### DIFF
--- a/kibana-notebooks/package.json
+++ b/kibana-notebooks/package.json
@@ -29,7 +29,8 @@
     "lodash": "^4.17.20",
     "@babel/cli": "^7.10.5",
     "@nteract/outputs": "^3.0.11",
-    "@nteract/presentational-components": "^3.4.3"
+    "@nteract/presentational-components": "^3.4.3",
+    "trim": "https://github.com/davidcui-amzn/trim.git"
   },
   "resolutions": {
     "prismjs": "^1.22.0"

--- a/kibana-notebooks/yarn.lock
+++ b/kibana-notebooks/yarn.lock
@@ -3424,6 +3424,10 @@ trim@0.0.1:
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
   integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
 
+"trim@https://github.com/davidcui-amzn/trim.git":
+  version "0.0.1"
+  resolved "https://github.com/davidcui-amzn/trim.git#279ee1d64575b95f929373232115b43914747d2d"
+
 trough@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
[component/trim](https://github.com/component/trim) library that is used by `nteract/outputs` causes a RegEx DOS error. Forked `trim` and changed implementation to address the RegEx DOS (needs confirmation from whitesourcing still) 

Makes sure package.json references forked version of trim.

[Forked trim](https://github.com/davidcui-amzn/trim)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
