### PR TITLE
Add Linux DCO to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,4 +3,26 @@
 *Description of changes:*
 
 
-By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+have the right to submit it under the open source license
+indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+of my knowledge, is covered under an appropriate open source
+license and I have the right under that license to submit that
+work with modifications, whether created in whole or in part
+by me, under the same open source license (unless I am
+permitted to submit under a different license), as indicated
+in the file; or
+
+(c) The contribution was provided directly to me by some other
+person who certified (a), (b) or (c) and I have not modified
+it.
+
+(d) I understand and agree that this project and the contribution
+are public and that a record of the contribution (including all
+personal information I submit with it, including my sign-off) is
+maintained indefinitely and may be redistributed consistent with
+this project or the open source license(s) involved.


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Add Linux Developer's Certificate of Origin to PR template as per ODFE 2021 Repo standards

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
