### PR TITLE
Replaced hardcoded paragraph execution time with real running time

### DIFF
--- a/kibana-notebooks/package.json
+++ b/kibana-notebooks/package.json
@@ -23,7 +23,8 @@
   },
   "devDependencies": {
     "cypress": "^5.0.0",
-    "eslint": "^6.8.0"
+    "eslint": "^6.8.0",
+    "performance-now": "^2.1.0"
   },
   "dependencies": {
     "@babel/cli": "^7.10.5",

--- a/kibana-notebooks/server/adaptors/default_backend.ts
+++ b/kibana-notebooks/server/adaptors/default_backend.ts
@@ -24,6 +24,7 @@ import {
   DefaultOutput,
 } from '../helpers/default_notebook_schema';
 import { formatNotRecognized, inputIsQuery } from '../helpers/query_helpers';
+import now from "performance-now";
 
 export class DefaultBackend implements NotebookAdaptor {
   backend = 'Default Backend';
@@ -277,7 +278,7 @@ export class DefaultBackend implements NotebookAdaptor {
       }
       if (paragraphInput.substring(0, 3) === '%sql' || paragraphInput.substring(0, 3) === '%ppl') {
         paragraphType = 'QUERY';
-      } 
+      }
       const inputObject = {
         inputType: paragraphType,
         inputText: paragraphInput,
@@ -312,6 +313,7 @@ export class DefaultBackend implements NotebookAdaptor {
       const updatedParagraphs = [];
       let index = 0;
       for (index = 0; index < paragraphs.length; ++index) {
+        const startTime = now();
         const updatedParagraph = { ...paragraphs[index] };
         if (paragraphs[index].input.inputType === 'MARKDOWN' && paragraphs[index].id === paragraphId) {
           updatedParagraph.dateModified = new Date().toISOString();
@@ -320,7 +322,7 @@ export class DefaultBackend implements NotebookAdaptor {
               {
                 outputType: 'QUERY',
                 result: paragraphs[index].input.inputText.substring(4, paragraphs[index].input.inputText.length),
-                execution_time: '0s',
+                execution_time: `${(now() - startTime).toFixed(3)} ms`,
               },
             ];
           } else if (paragraphs[index].input.inputText.substring(0, 3) === '%md') {
@@ -328,27 +330,27 @@ export class DefaultBackend implements NotebookAdaptor {
               {
                 outputType: 'MARKDOWN',
                 result: paragraphs[index].input.inputText.substring(4, paragraphs[index].input.inputText.length),
-                execution_time: '0s',
+                execution_time: `${(now() - startTime).toFixed(3)} ms`,
               },
-            ];            
+            ];
           } else if (paragraphs[index].input.inputType === 'VISUALIZATION' && paragraphs[index].id === paragraphId) {
             updatedParagraph.dateModified = new Date().toISOString();
             updatedParagraph.output = [
               {
                 outputType: 'VISUALIZATION',
                 result: '',
-                execution_time: '0s',
+                execution_time: `${(now() - startTime).toFixed(3)} ms`,
               },
             ];
-        } else if (formatNotRecognized(paragraphs[index].input.inputText)) {
+          } else if (formatNotRecognized(paragraphs[index].input.inputText)) {
             updatedParagraph.output = [
               {
                 outputType: 'MARKDOWN',
                 result: 'Please select an input type (%sql, %ppl, or %md)',
-                execution_time: '0s',
+                execution_time: `${(now() - startTime).toFixed(3)} ms`,
               },
-            ];     
-         }
+            ];
+          }
         }
         updatedParagraphs.push(updatedParagraph);
       }


### PR DESCRIPTION
*Issue #, if available:*
#80 

*Description of changes:*
Replaced hardcoded exec time in paragraph running calls with real exec time for future feature to display the exec time in the UI (if any). Keeps fixed 3 digits of fraction part, time unit is millisecond (ms).

 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. 
